### PR TITLE
Feat: internal link support

### DIFF
--- a/SastWiki.Core/Contracts/InternalLink/IInternalLinkCreator.cs
+++ b/SastWiki.Core/Contracts/InternalLink/IInternalLinkCreator.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SastWiki.Core.Contracts.InternalLink
+{
+    public interface IInternalLinkCreator
+    {
+        public Uri Create(string path, Dictionary<string, string> query);
+    }
+}

--- a/SastWiki.Core/Contracts/InternalLink/IInternalLinkHandler.cs
+++ b/SastWiki.Core/Contracts/InternalLink/IInternalLinkHandler.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SastWiki.Core.Contracts.InternalLink
+{
+    public interface IInternalLinkHandler
+    {
+        public void Trigger(Uri ilink);
+    }
+}

--- a/SastWiki.Core/Contracts/InternalLink/IInternalLinkService.cs
+++ b/SastWiki.Core/Contracts/InternalLink/IInternalLinkService.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SastWiki.Core.Contracts.InternalLink
+{
+    public interface IInternalLinkService
+    {
+        public Dictionary<string, EventHandler<NameValueCollection>> Paths { get; }
+
+        public bool Register(string path, EventHandler<NameValueCollection> handler);
+
+        public bool ContainsPath(string path);
+    }
+}

--- a/SastWiki.Core/Contracts/InternalLink/IInternalLinkValidator.cs
+++ b/SastWiki.Core/Contracts/InternalLink/IInternalLinkValidator.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SastWiki.Core.Contracts.InternalLink
+{
+    public interface IInternalLinkValidator
+    {
+        public string SchemeName { get; init; }
+        public string HostName { get; init; }
+        public bool Validate(Uri uri);
+    }
+}

--- a/SastWiki.Core/Services/InternalLink/InternalLinkCreator.cs
+++ b/SastWiki.Core/Services/InternalLink/InternalLinkCreator.cs
@@ -1,0 +1,35 @@
+﻿using SastWiki.Core.Contracts.InternalLink;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SastWiki.Core.Services.InternalLink
+{
+    public class InternalLinkCreator(IInternalLinkValidator validator, IInternalLinkService service)
+        : IInternalLinkCreator
+    {
+        public const string _schemeName = "wiki";
+        public const string _hostName = "sast-wiki";
+
+        public Uri Create(string path, Dictionary<string, string> query)
+        // NameValueCollection的性能似乎不如Dictionary<string,string>？
+        {
+            if (!service.ContainsPath(path))
+                throw new ArgumentException("path is not registered");
+            StringBuilder sb = new StringBuilder();
+            sb.Append($"{validator.SchemeName}://{validator.HostName}{path}");
+            if (query.Count > 0)
+            {
+                sb.Append("?");
+                foreach (KeyValuePair<string, string> kvp in query)
+                {
+                    sb.Append($"{kvp.Key}={kvp.Value}&");
+                }
+                sb.Remove(sb.Length - 1, 1);
+            }
+            return new Uri(sb.ToString());
+        }
+    }
+}

--- a/SastWiki.Core/Services/InternalLink/InternalLinkHandler.cs
+++ b/SastWiki.Core/Services/InternalLink/InternalLinkHandler.cs
@@ -1,0 +1,27 @@
+﻿using SastWiki.Core.Contracts.InternalLink;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace SastWiki.Core.Services.InternalLink
+{
+    public class InternalLinkHandler(
+        IInternalLinkService internalLinkService,
+        IInternalLinkValidator internalLinkValidator
+    ) : IInternalLinkHandler
+    {
+        public void Trigger(Uri ilink)
+        {
+            if (internalLinkValidator.Validate(ilink))
+            {
+                internalLinkService.Paths[ilink.AbsolutePath].Invoke(
+                    this,
+                    HttpUtility.ParseQueryString(ilink.Query)
+                );
+            }
+        }
+    }
+}

--- a/SastWiki.Core/Services/InternalLink/InternalLinkService.cs
+++ b/SastWiki.Core/Services/InternalLink/InternalLinkService.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SastWiki.Core.Contracts.InternalLink;
+
+namespace SastWiki.Core.Services.InternalLink
+{
+    public class InternalLinkService : IInternalLinkService
+    {
+        public Dictionary<string, EventHandler<NameValueCollection>> Paths { get; private set; }
+
+        public InternalLinkService()
+        {
+            Paths = [];
+        }
+
+        public bool Register(string path, EventHandler<NameValueCollection> handler) =>
+            Paths.TryAdd(path, handler);
+
+        public bool ContainsPath(string path) => Paths.ContainsKey(path);
+    }
+}

--- a/SastWiki.Core/Services/InternalLink/InternalLinkValidator.cs
+++ b/SastWiki.Core/Services/InternalLink/InternalLinkValidator.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SastWiki.Core.Contracts.InternalLink;
+
+namespace SastWiki.Core.Services.InternalLink
+{
+    public class InternalLinkValidator(IInternalLinkService internallinkservice)
+        : IInternalLinkValidator
+    {
+        public string SchemeName { get; init; } = "wiki";
+        public string HostName { get; init; } = "sast-wiki";
+
+        public bool Validate(Uri uri) =>
+            uri.Scheme == SchemeName
+            && uri.Host == HostName
+            && internallinkservice.ContainsPath(uri.AbsolutePath);
+    }
+}

--- a/SastWiki.WPF/App.xaml.cs
+++ b/SastWiki.WPF/App.xaml.cs
@@ -5,6 +5,10 @@ using SastWiki.WPF.Views.Pages;
 using SastWiki.WPF.ViewModels;
 using SastWiki.WPF.Contracts;
 using SastWiki.WPF.Services;
+using SastWiki.Core.Contracts;
+using SastWiki.Core.Services;
+using SastWiki.Core.Contracts.InternalLink;
+using SastWiki.Core.Services.InternalLink;
 
 namespace SastWiki.WPF
 {
@@ -53,6 +57,10 @@ namespace SastWiki.WPF
                         // Register Services
                         services.AddSingleton<INavigationService, NavigationService>();
                         services.AddSingleton<IMarkdownProcessor, MarkdownProcessor>();
+                        services.AddSingleton<IInternalLinkService, InternalLinkService>();
+                        services.AddSingleton<IInternalLinkHandler, InternalLinkHandler>();
+                        services.AddSingleton<IInternalLinkValidator, InternalLinkValidator>();
+                        services.AddSingleton<IInternalLinkCreator, InternalLinkCreator>();
 
                         // Register ViewModels
                         services.AddSingleton<MainWindowVM>();
@@ -72,6 +80,29 @@ namespace SastWiki.WPF
                     }
                 )
                 .Build();
+
+            // Register Internal Links
+            var internalLinkService = GetService<IInternalLinkService>();
+            internalLinkService.Register(
+                "/Home",
+                (sender, e) =>
+                {
+                    var navigationService = GetService<INavigationService>();
+                    navigationService.NavigateTo(GetService<HomePage>());
+                }
+            );
+
+            internalLinkService.Register(
+                "/Entry",
+                (sender, e) =>
+                {
+                    if (int.TryParse(e["id"], out var id))
+                    {
+                        var navigationService = GetService<INavigationService>();
+                        navigationService.NavigateTo(GetService<EntryViewPage>(), id.ToString());
+                    }
+                }
+            );
         }
 
         private void Application_Startup(object sender, StartupEventArgs e)

--- a/SastWiki.WPF/SastWiki.WPF.csproj
+++ b/SastWiki.WPF/SastWiki.WPF.csproj
@@ -21,4 +21,8 @@
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2210.55" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\SastWiki.Core\SastWiki.Core.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
初步实现App内部链接的支持（完全是为了WebView2）
格式类似于：
wiki://sast-wiki/Entry?id=114514
这当中所有部分应该都挺方便改的
Scheme和Hostname部分在InternalLinkValidator里面，而Path及其触发处理方法则在App.xaml.cs里面通过IInternalLinkService.Register完成注册。
也提供了创建内部链接需要的方法，即IInternalLinkCreator.Create，可以方便的生成内部链接，无需操心Scheme和Hostname部分以及Uri是否符合规范。

总之是在不对NavigationService动刀的基础上完成了，内部链接也可以通过绑定个Lambda到对应Path上实现页面跳转，可以参考目前App.xaml.cs里面写好了的Entry的绑定。

虽然Commit里写的是没测试过，实际上还是测试过了一次的（
不保证能用（